### PR TITLE
Use schema less service Url

### DIFF
--- a/src/ServiceNominatim.php
+++ b/src/ServiceNominatim.php
@@ -23,7 +23,7 @@ class ServiceNominatim extends BaseService
     /**
      * @var string the URL of the service
      */
-    public $serviceUrl = 'http://nominatim.openstreetmap.org/';
+    public $serviceUrl = '//nominatim.openstreetmap.org/';
     /**
      * @var array additional URL parameters (strings) that will be added to geocoding requests
      */


### PR DESCRIPTION
Use schema less service Url otherwise the geolocator requests are bloced on modern browsers when embedded in a secure page which is served usnig TLS (using https scheme)